### PR TITLE
morph::Tools::randDouble() -> morph::randDouble()

### DIFF
--- a/models/dev/Jinle.cpp
+++ b/models/dev/Jinle.cpp
@@ -12,6 +12,7 @@
 #include <morph/Scale.h>
 #include <morph/Vector.h>
 #include <morph/ShapeAnalysis.h>
+#include <morph/rngd.h>
 
 //#include <omp.h>
 #include <numeric>
@@ -102,10 +103,10 @@ public:
 
     void decayX(void){
         for(int i=0;i<CX.nhex;i++){
-            CX.X[i] = CX.X[i]*decayConstant + oneMinusDecay*CXcpy[i] + (morph::Tools::randDouble()-0.5)*noiseScale; // should be norm distr.
+            CX.X[i] = CX.X[i]*decayConstant + oneMinusDecay*CXcpy[i] + (morph::randDouble()-0.5)*noiseScale; // should be norm distr.
         }
         for(int i=0;i<CX2.nhex;i++){
-            CX2.X[i] = CX2.X[i]*decayConstant + oneMinusDecay*CX2cpy[i] + (morph::Tools::randDouble()-0.5)*noiseScale;
+            CX2.X[i] = CX2.X[i]*decayConstant + oneMinusDecay*CX2cpy[i] + (morph::randDouble()-0.5)*noiseScale;
         }
     }
 
@@ -542,8 +543,8 @@ int main(int argc, char **argv){
 
         for (unsigned int i = 0; i < steps; i++) {
 
-            p = floor(morph::Tools::randDouble() * Net.HCM.PreLoadedPatterns.size());
-            direction = morph::Tools::randDouble() * M_PI * 2.0;
+            p = floor(morph::randDouble() * Net.HCM.PreLoadedPatterns.size());
+            direction = morph::randDouble() * M_PI * 2.0;
 
             for (unsigned int j = 0; j < stimIncs; j++) {
 

--- a/models/dev/antolik2011.cpp
+++ b/models/dev/antolik2011.cpp
@@ -10,6 +10,7 @@
 #include <morph/VisualDataModel.h>
 #include <morph/Scale.h>
 #include <morph/Vector.h>
+#include <morph/rngd.h>
 
 typedef morph::VisualDataModel<FLT>* VdmPtr;
 
@@ -86,10 +87,10 @@ public:
 
     void decayX(void){
         for(int i=0;i<CX.nhex;i++){
-            CX.X[i] = CX.X[i]*decayConstant + oneMinusDecay*CXcpy[i] + (morph::Tools::randDouble()-0.5)*noiseScale; // should be norm distr.
+            CX.X[i] = CX.X[i]*decayConstant + oneMinusDecay*CXcpy[i] + (morph::randDouble()-0.5)*noiseScale; // should be norm distr.
         }
         for(int i=0;i<CX2.nhex;i++){
-            CX2.X[i] = CX2.X[i]*decayConstant + oneMinusDecay*CX2cpy[i] + (morph::Tools::randDouble()-0.5)*noiseScale;
+            CX2.X[i] = CX2.X[i]*decayConstant + oneMinusDecay*CX2cpy[i] + (morph::randDouble()-0.5)*noiseScale;
         }
     }
 
@@ -490,8 +491,8 @@ int main(int argc, char **argv){
         // UPDATE MODEL
         for(unsigned int i=0;i<steps;i++){
 
-            p = floor(morph::Tools::randDouble() * Net.HCM.PreLoadedPatterns.size());
-            direction = morph::Tools::randDouble()*M_PI*2.0;
+            p = floor(morph::randDouble() * Net.HCM.PreLoadedPatterns.size());
+            direction = morph::randDouble()*M_PI*2.0;
 
             for(unsigned int j=0;j<stimIncs;j++){
 

--- a/models/examples/stevens2013.cpp
+++ b/models/examples/stevens2013.cpp
@@ -454,8 +454,7 @@ int main(int argc, char **argv){
         } break;
 
     }
-    
+
 
     return 0.;
 }
-

--- a/topo/gcal.h
+++ b/topo/gcal.h
@@ -4,6 +4,7 @@
 #include <morph/Vector.h>
 #include <morph/HdfData.h>
 #include <morph/Config.h>
+#include <morph/rngd.h>
 
 class gcal : public Network<FLT> {
 
@@ -147,9 +148,9 @@ class gcal : public Network<FLT> {
                 std::vector<double> sB(nGauss);
                 std::vector<double> amp(nGauss);
                 for(int i=0;i<nGauss;i++){
-                    x[i] = (morph::Tools::randDouble()-0.5)*xRange;
-                    y[i] = (morph::Tools::randDouble()-0.5)*yRange;
-                    t[i] = morph::Tools::randDouble()*M_PI;
+                    x[i] = (morph::randDouble()-0.5)*xRange;
+                    y[i] = (morph::randDouble()-0.5)*yRange;
+                    t[i] = morph::randDouble()*M_PI;
                     sA[i] = sigmaA;
                     sB[i] = sigmaB;
                     amp[i] = 1.0;
@@ -166,7 +167,7 @@ class gcal : public Network<FLT> {
             } break;
             default:{
                 for(int i=0;i<HCM.C.n;i++){
-                    HCM.C.vsquare[i].X = morph::Tools::randDouble();
+                    HCM.C.vsquare[i].X = morph::randDouble();
                 }
                 HCM.step();
                 IN.X = HCM.X;

--- a/topo/topo.h
+++ b/topo/topo.h
@@ -2,6 +2,7 @@
 #include <morph/HexGrid.h>
 #include <morph/RD_Base.h>
 #include <morph/Config.h>
+#include <morph/rngd.h>
 
 template <class Flt>
 class Network{
@@ -94,8 +95,8 @@ public:
     // initialize connections for each destination sheet unit
     #pragma omp parallel for
         for(unsigned int i=0;i<nDst;i++){
-            Flt jitterx = jitter * (morph::Tools::randDouble()-0.5);
-            Flt jittery = jitter * (morph::Tools::randDouble()-0.5);
+            Flt jitterx = jitter * (morph::randDouble()-0.5);
+            Flt jittery = jitter * (morph::randDouble()-0.5);
             for(unsigned int j=0;j<nSrc;j++){
                 Flt dx = (hgSrc->vhexen[j]->x+jitterx-hgDst->vhexen[i]->x);
                 Flt dy = (hgSrc->vhexen[j]->y+jittery-hgDst->vhexen[i]->y);
@@ -781,8 +782,8 @@ public:
     void stepPreloaded(int p){
 
         // Jitter if the sample width is less than the image width
-        int offx = floor(morph::Tools::randDouble()*(patternsWid-C.nx));
-        int offy = floor(morph::Tools::randDouble()*(patternsWid-C.ny));
+        int offx = floor(morph::randDouble()*(patternsWid-C.nx));
+        int offy = floor(morph::randDouble()*(patternsWid-C.ny));
 
         int k=0;
         for(int i=0;i<C.nx;i++){
@@ -808,7 +809,7 @@ public:
     }
 
     void stepPreloaded(void){
-        int p = floor(morph::Tools::randDouble()*PreLoadedPatterns.size());
+        int p = floor(morph::randDouble()*PreLoadedPatterns.size());
         stepPreloaded(p);
     }
 };


### PR DESCRIPTION
Replaces calls to morph::Tools::randDouble() from tools.h with calls to morph::randDouble() from rngd.h